### PR TITLE
Add format-on-save and configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,28 +1,52 @@
 {
 	"name": "vsc-rustfmt",
 	"description": "Allows you to run rustfmt from VS Code",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"publisher": "Connorcpu",
 	"engines": {
 		"vscode": "^0.10.1"
 	},
+	
 	"categories": [
-		"Other"
+		"Languages"
 	],
+	
 	"activationEvents": [
-		"onCommand:extension.rustfmt"
+		"onCommand:rustfmt.fmt",
+		"onLanguage:rust"
 	],
+	
 	"main": "./out/src/extension",
 	"contributes": {
 		"commands": [{
-			"command": "extension.rustfmt",
+			"command": "rustfmt.fmt",
 			"title": "Format with rustfmt"
 		}]
 	},
+	
+	"configuration": {
+		"type": "object",
+		"title": "Rustfmt configuration",
+		"properties": {
+			"rustfmt.bin": {
+				"type": "string",
+				"default": "",
+				"description": "The path to the rustfmt binary"
+			},
+			
+			"rustfmt.formatOnSave": {
+				"type": "boolean",
+				"default": true,
+				"description": "Whether to format Rust code on save"
+			}
+		}
+	},
+
 	"scripts": {
 		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
 		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
 	},
+	
 	"devDependencies": {
 		"typescript": "^1.6.2",
 		"vscode": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
 		"onLanguage:rust"
 	],
 	
+	"extensionDependencies": [
+		"vscode.rust"
+	],
+	
 	"main": "./out/src/extension",
 	"contributes": {
 		"commands": [{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,23 +1,34 @@
 import * as vscode from 'vscode';
 import * as child_process from 'child_process';
 
+let config;
+
+function formatDocument(document: string) {
+	let bin = config.bin === '' ? 'rustfmt' : config.bin;
+	let result = child_process.spawnSync(bin, ['--write-mode', 'overwrite', document]);
+	if (result.error) {
+		vscode.window.showErrorMessage(result.error.toString());
+	} else if(result.stderr.toString().length != 0) {
+		let channel = vscode.window.createOutputChannel('Rustfmt Output');
+		channel.append(result.stderr.toString());
+		channel.show();
+	}
+}
+
 export function activate(context: vscode.ExtensionContext) {
-	var disposable = vscode.commands.registerTextEditorCommand("extension.rustfmt", (editor: vscode.TextEditor) => {
-		editor.document.save().then((fulfilled: boolean) => {
-			let file = editor.document.fileName;
-			let result = child_process.spawnSync("rustfmt", ["--write-mode", "overwrite", file]);
-			
-			if (result.error) {
-				vscode.window.showErrorMessage(result.error.toString());
-			} else {
-				if (result.stderr.toString().length != 0) {
-					vscode.window.showErrorMessage("Something went wrong during formatting");
-				} else {
-					vscode.window.showInformationMessage("Formatted!");
-				}
-			}
-		});
-	});
+	config = vscode.workspace.getConfiguration('rustfmt');
 	
-	context.subscriptions.push(disposable);
+	// Manual fmt command
+	context.subscriptions.push(vscode.commands.registerTextEditorCommand('rustfmt.fmt', editor => {
+		editor.document.save().then(fulfilled => {
+			formatDocument(editor.document.fileName);
+		});
+	}));
+	
+	// Automatic save handler
+	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(target => {
+		if(/\.rs$/.test(target.fileName) && (config.formatOnSave || true)) {
+			formatDocument(target.fileName);
+		}
+	}));
 }


### PR DESCRIPTION
I took the liberty of making the command name more conventional as well. I would also recommend changing the plugin name to `vscode-rustfmt` to better align with the styles shown in Microsoft repos.
