### PR TITLE
Missing default config causes plugin fail to execute with: error spwawnsync undefined enoent

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,14 +17,14 @@ function formatDocument(document: string) {
 
 export function activate(context: vscode.ExtensionContext) {
 	config = vscode.workspace.getConfiguration('rustfmt');
-
+	
 	// Manual fmt command
 	context.subscriptions.push(vscode.commands.registerTextEditorCommand('rustfmt.fmt', editor => {
 		editor.document.save().then(fulfilled => {
 			formatDocument(editor.document.fileName);
 		});
 	}));
-
+	
 	// Automatic save handler
 	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(target => {
 		if(/\.rs$/.test(target.fileName) && (config.formatOnSave || true)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as child_process from 'child_process';
 let config;
 
 function formatDocument(document: string) {
-	let bin = config.bin === '' ? 'rustfmt' : config.bin;
+	let bin = !config.bin ? 'rustfmt' : config.bin;
 	let result = child_process.spawnSync(bin, ['--write-mode', 'overwrite', document]);
 	if (result.error) {
 		vscode.window.showErrorMessage(result.error.toString());
@@ -17,14 +17,14 @@ function formatDocument(document: string) {
 
 export function activate(context: vscode.ExtensionContext) {
 	config = vscode.workspace.getConfiguration('rustfmt');
-	
+
 	// Manual fmt command
 	context.subscriptions.push(vscode.commands.registerTextEditorCommand('rustfmt.fmt', editor => {
 		editor.document.save().then(fulfilled => {
 			formatDocument(editor.document.fileName);
 		});
 	}));
-	
+
 	// Automatic save handler
 	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(target => {
 		if(/\.rs$/.test(target.fileName) && (config.formatOnSave || true)) {


### PR DESCRIPTION
For some reason the default configuration is not applied on VSCode (1.8.1) and the missing bin config value is undefined instead of an empty string. This fix is not complete as it only makes the missing bin config check more universal - if you like. A more proper fix would be to make sure the default config (empty string) is actually registered when the plugin is added to vscode.